### PR TITLE
fix/monit-reg; improve regex to match record rules metrics

### DIFF
--- a/collection-scripts/gather_monitoring
+++ b/collection-scripts/gather_monitoring
@@ -197,10 +197,8 @@ function gf_discovery_metrics_from_dashboards() {
             -H "Authorization: Bearer ${OCP_TOKEN}" \
             "${GF_URL}/api/dashboards/uid/${DUID}" > "${GF_PATH}/dashboard_${NAME}.json"
 
-        ${JQ_PATH} .dashboard.rows[].panels[].targets[].expr \
-            "${GF_PATH}/dashboard_${NAME}.json" \
-            | egrep -o '\((\w+){\)*' \
-            | tr -d '({' > "${GF_PATH}/dashboard_${NAME}_metrics.txt"
+        ${JQ_PATH} -r '.dashboard.rows[].panels[].targets[].expr | match("\\(([\\w:]+){.*").captures[].string' \
+            "${GF_PATH}/dashboard_${NAME}.json" > "${GF_PATH}/dashboard_${NAME}_metrics.txt"
     done < "${GF_PATH}/dashboards.txt"
 
     echo -ne "INFO: Grouping all dashboards' metrics to ${GF_PATH}/dashboards_metrics.txt"


### PR DESCRIPTION
Fix regex to match metrics created by recording rules and use native jq regex expression:

FROM
~~~bash
$ jq -r '.dashboard.rows[].panels[].targets[].expr '  data/must-gather/monitoring/grafana/dashboard_kubernetes-compute-resources-node-pods.json | egrep -o '\((\w+){\)*' | tr -d '({' |wc -l
8

$ jq -r '.dashboard.rows[].panels[].targets[].expr '  data/must-gather/monitoring/grafana/dashboard_kubernetes-compute-resources-node-pods.json | egrep -o '\((\w+){\)*' | tr -d '({' 
kube_pod_container_resource_requests_cpu_cores
kube_pod_container_resource_requests_cpu_cores
kube_pod_container_resource_limits_cpu_cores
kube_pod_container_resource_limits_cpu_cores
kube_pod_container_resource_requests_memory_bytes
kube_pod_container_resource_requests_memory_bytes
kube_pod_container_resource_limits_memory_bytes
kube_pod_container_resource_limits_memory_bytes
~~~

TO:
~~~bash
$ jq -r '.dashboard.rows[].panels[].targets[].expr | match("\\(([\\w:]+){.*").captures[].string'  data/must-gather/monitoring/grafana/dashboard_kubernetes-compute-resources-node-pods.json |wc -l
15

$ jq -r '.dashboard.rows[].panels[].targets[].expr | match("\\(([\\w:]+){.*").captures[].string'  data/must-gather/monitoring/grafana/dashboard_kubernetes-compute-resources-node-pods.json
node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate
node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate
kube_pod_container_resource_requests_cpu_cores
node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate
kube_pod_container_resource_limits_cpu_cores
node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate
node_namespace_pod_container:container_memory_working_set_bytes
node_namespace_pod_container:container_memory_working_set_bytes
kube_pod_container_resource_requests_memory_bytes
node_namespace_pod_container:container_memory_working_set_bytes
kube_pod_container_resource_limits_memory_bytes
node_namespace_pod_container:container_memory_working_set_bytes
node_namespace_pod_container:container_memory_rss
node_namespace_pod_container:container_memory_cache
node_namespace_pod_container:container_memory_swap
~~~