### PR TITLE
fix/monit-regex: fix the jq version to download.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,11 @@ FROM registry.svc.ci.openshift.org/openshift/release:golang-1.12 AS builder
 WORKDIR /go/src/github.com/openshift/must-gather
 COPY . .
 ENV GO_PACKAGE github.com/openshift/must-gather
+RUN curl -Ls https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 -o /usr/bin/jq \
+    && strip /usr/bin/jq \
+    && chmod u+x /usr/bin/jq
 
 FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:cli
 COPY --from=builder /go/src/github.com/openshift/must-gather/collection-scripts/* /usr/bin/
+COPY --from=builder /usr/bin/jq /usr/bin/jq
 

--- a/collection-scripts/gather_monitoring
+++ b/collection-scripts/gather_monitoring
@@ -197,8 +197,14 @@ function gf_discovery_metrics_from_dashboards() {
             -H "Authorization: Bearer ${OCP_TOKEN}" \
             "${GF_URL}/api/dashboards/uid/${DUID}" > "${GF_PATH}/dashboard_${NAME}.json"
 
+        # discovery metrics defined on panels that matchs: (metric_name|relabeled_metric:metric_name:oper)
         ${JQ_PATH} -r '.dashboard.rows[].panels[].targets[].expr |match("\\(([\\w:]+){.*").captures[].string' \
             "${GF_PATH}/dashboard_${NAME}.json" > "${GF_PATH}/dashboard_${NAME}_metrics.txt"
+
+        # discovery metrics defined on variables that matchs: (metric_name|relabeled_metric:metric_name:oper)
+        ${JQ_PATH} -r '.dashboard.rows[].panels[].targets[].expr |tostring |match(".*\\\"label_values\\(([a-z:_]+).*").captures[].string' \
+            "${GF_PATH}/dashboard_${NAME}.json" > "${GF_PATH}/dashboard_${NAME}_metrics.txt"
+
     done < "${GF_PATH}/dashboards.txt"
 
     echo -ne "INFO: Grouping all dashboards' metrics to ${GF_PATH}/dashboards_metrics.txt"

--- a/collection-scripts/gather_monitoring
+++ b/collection-scripts/gather_monitoring
@@ -197,7 +197,8 @@ function gf_discovery_metrics_from_dashboards() {
             -H "Authorization: Bearer ${OCP_TOKEN}" \
             "${GF_URL}/api/dashboards/uid/${DUID}" > "${GF_PATH}/dashboard_${NAME}.json"
 
-        ${JQ_PATH} -r '.dashboard.rows[].panels[].targets[].expr | match("\\(([\\w:]+){.*").captures[].string' \
+        ${JQ_PATH} \
+            -r \'.dashboard.rows[].panels[].targets[].expr | match("\\(([\\w:]+){.*").captures[].string \' \
             "${GF_PATH}/dashboard_${NAME}.json" > "${GF_PATH}/dashboard_${NAME}_metrics.txt"
     done < "${GF_PATH}/dashboards.txt"
 

--- a/collection-scripts/gather_monitoring
+++ b/collection-scripts/gather_monitoring
@@ -106,7 +106,7 @@ function install_jq() {
     # install jq from binary (required to Dashnoard parser)
     export JQ_PATH=/usr/local/bin/jq
     "${CURL_CMD[@]}" -o "${JQ_PATH}" \
-      http://stedolan.github.io/jq/download/linux64/jq && \
+      https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 && \
       chmod +x "${JQ_PATH}"
 }
 
@@ -197,8 +197,7 @@ function gf_discovery_metrics_from_dashboards() {
             -H "Authorization: Bearer ${OCP_TOKEN}" \
             "${GF_URL}/api/dashboards/uid/${DUID}" > "${GF_PATH}/dashboard_${NAME}.json"
 
-        ${JQ_PATH} \
-            -r \'.dashboard.rows[].panels[].targets[].expr | match("\\(([\\w:]+){.*").captures[].string \' \
+        ${JQ_PATH} -r '.dashboard.rows[].panels[].targets[].expr |match("\\(([\\w:]+){.*").captures[].string' \
             "${GF_PATH}/dashboard_${NAME}.json" > "${GF_PATH}/dashboard_${NAME}_metrics.txt"
     done < "${GF_PATH}/dashboards.txt"
 

--- a/collection-scripts/gather_monitoring
+++ b/collection-scripts/gather_monitoring
@@ -203,7 +203,7 @@ function gf_discovery_metrics_from_dashboards() {
 
         # discovery metrics defined on variables that matchs: (metric_name|relabeled_metric:metric_name:oper)
         ${JQ_PATH} -r '.dashboard.rows[].panels[].targets[].expr |tostring |match(".*\\\"label_values\\(([a-z:_]+).*").captures[].string' \
-            "${GF_PATH}/dashboard_${NAME}.json" > "${GF_PATH}/dashboard_${NAME}_metrics.txt"
+            "${GF_PATH}/dashboard_${NAME}.json" >> "${GF_PATH}/dashboard_${NAME}_metrics.txt"
 
     done < "${GF_PATH}/dashboards.txt"
 


### PR DESCRIPTION
Set the version of jq to be used, default is 1.4 and does not support regex as we are using in the project. Setting to use 1.5 or later.