### PR TITLE
chore/Dockerfile-jq: add Dependency to gather_monitoring

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,11 @@ FROM registry.svc.ci.openshift.org/openshift/release:golang-1.12 AS builder
 WORKDIR /go/src/github.com/openshift/must-gather
 COPY . .
 ENV GO_PACKAGE github.com/openshift/must-gather
+RUN curl -Ls https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 -o /usr/bin/jq \
+    && strip /usr/bin/jq \
+    && chmod u+x /usr/bin/jq
 
 FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:cli
 COPY --from=builder /go/src/github.com/openshift/must-gather/collection-scripts/* /usr/bin/
+COPY --from=builder /usr/bin/jq /usr/bin/jq
 


### PR DESCRIPTION
Proposal to add jq to Dockerfile, alternative of downloading it when must-gather monitoring script is running (https://github.com/openshift/must-gather/pull/214)

It The striped binary has about ~2.3Mi to increase to final image.