### PR TITLE
feat/monitoring: collecting OS top for top30 process

### DIFF
--- a/collection-scripts/gather_monitoring
+++ b/collection-scripts/gather_monitoring
@@ -8,7 +8,7 @@ set -o pipefail
 BASE_COLLECTION_PATH="../must-gather"
 MONITORING_PATH="${BASE_COLLECTION_PATH}/monitoring"
 
-mkdir -p "${MONITORING_PATH}"
+mkdir -p "${MONITORING_PATH}/"{top,}
 
 MONITORING_ROUTE="$(oc get routes -n openshift-monitoring prometheus-k8s -o jsonpath={.status.ingress[0].host})"
 SA_TOKEN="$(oc sa get-token default)"
@@ -28,19 +28,30 @@ oc get\
 rm "${MONITORING_PATH}/ca-bundle.crt"
 
 function get_top_nodes {
-    oc adm top node &> "${MONITORING_PATH}/adm-top-nodes.out"
+    oc adm top node &> "${MONITORING_PATH}/top/adm-top-nodes.out"
 }
 
 function get_top_pods {
-    oc adm top pod -A &> "${MONITORING_PATH}/adm-top-pods.out"
+    oc adm top pod -A &> "${MONITORING_PATH}/top/adm-top-pods.out"
 }
 
 function get_top_images {
-    oc adm top images &> "${MONITORING_PATH}/adm-top-images.out"
+    oc adm top images &> "${MONITORING_PATH}/top/adm-top-images.out"
 }
 
 function get_top_is {
-    oc adm top imagestreams &> "${MONITORING_PATH}/adm-top-imagestreams.out"
+    oc adm top imagestreams &> "${MONITORING_PATH}/top/adm-top-imagestreams.out"
+}
+
+function get_nodes {
+    oc get nodes -o jsonpath='{.items[*].metadata.name}'
+}
+
+function get_nodes_os_top {
+    for NODE in `get_nodes || ''`; do
+        echo $NODE
+        oc debug node/${NODE} -- chroot /host /bin/bash -c "top -bc -n1 -w192 |head -n 30" &>> "${MONITORING_PATH}/top/os-top-${NODE}.out"
+    done
 }
 
 function get_top {
@@ -56,6 +67,9 @@ function get_top {
 
     echo "INFO: Collecting 'oc adm top imagestreams'"
     get_top_is || true
+
+    echo "INFO: Collecting OS top 30 proc: 'top -bc -n1 -w192'"
+    get_nodes_os_top || true
 }
 
 get_top


### PR DESCRIPTION
Collecting OS top info. As it schedules a new pod for each node, in internal lab it took 30s by node. IMHO it it could be a problem in large environments. For other way, it can provide a good overview from OS side **without needing to request sosreport that will take too much time and resource usage**.

Lab environment: Quicklab, domain hidden from CEE Lab suffix.

[1] must-gather execution time
~~~
$ oc adm must-gather --image=quay.io/rhn_support_mrbraga/must-gather:647f632-os-top
[...]
[must-gather-xpxhl] POD 2021-06-21T14:25:58.835289829Z INFO: Collecting 'oc adm top node'
[must-gather-xpxhl] POD 2021-06-21T14:26:00.003514226Z INFO: Collecting 'oc adm top pod'
[must-gather-xpxhl] POD 2021-06-21T14:26:00.532513816Z INFO: Collecting 'oc adm top images'
[must-gather-xpxhl] POD 2021-06-21T14:26:01.509482885Z INFO: Collecting 'oc adm top imagestreams'
>>>
[must-gather-xpxhl] POD 2021-06-21T14:26:02.217842580Z INFO: Collecting OS top 30 proc: 'top -bc -n1 -w192'
[must-gather-xpxhl] POD 2021-06-21T14:26:02.527860169Z master-0.sharedocp4upi46.lab.rdu2.mylab.com
[must-gather-xpxhl] POD 2021-06-21T14:26:26.636187158Z master-1.sharedocp4upi46.lab.rdu2.mylab.com
[must-gather-xpxhl] POD 2021-06-21T14:27:07.614792607Z master-2.sharedocp4upi46.lab.rdu2.mylab.com
[must-gather-xpxhl] POD 2021-06-21T14:27:32.405433503Z worker-0.sharedocp4upi46.lab.rdu2.mylab.com
[must-gather-xpxhl] POD 2021-06-21T14:27:59.867870839Z worker-1.sharedocp4upi46.lab.rdu2.mylab.com
[must-gather-xpxhl] POD 2021-06-21T14:28:33.411412182Z worker-2.sharedocp4upi46.lab.rdu2.mylab.com
[...]
~~~

[2] one output from OS Top
~~~
$ cat must-gather.local.7069330323604724452/quay-io-rhn-support-mrbraga-must-gather-sha256-68615cca1cdbe5626b1da8d7f7e8245897f405d91892ba7302923f1b81e7ea51/monitoring/top/os-top-master-0.sharedocp4upi46.lab.rdu2.mylab.com |head -n 15
Starting pod/master-0sharedocp4upi46labrdu2mylabcom-debug ...
To use host binaries, run `chroot /host`
top - 14:26:25 up 1 day,  8:48,  0 users,  load average: 2.79, 2.18, 1.97
Tasks: 305 total,   2 running, 303 sleeping,   0 stopped,   0 zombie
%Cpu(s):  7.1 us,  9.1 sy,  0.0 ni, 75.8 id,  1.0 wa,  1.0 hi,  1.0 si,  5.1 st
MiB Mem :  16034.3 total,   2953.0 free,   4462.6 used,   8618.7 buff/cache
MiB Swap:      0.0 total,      0.0 free,      0.0 used.  12757.0 avail Mem 

    PID USER      PR  NI    VIRT    RES    SHR S  %CPU  %MEM     TIME+ COMMAND
   1649 root      20   0 2813456 231636  64368 S  17.4   1.4 309:44.82 kubelet --config=/etc/kubernetes/kubelet.conf --bootstrap-kubeconfig=/etc/kubernetes/kubeconfig --kubeconfig=/var/lib/k+
   1219 root      20   0  220164  37520  35904 S   4.3   0.2   0:06.17 /usr/libexec/sssd/sssd_nss --uid 0 --gid 0 --logger=files
   1611 root      20   0 2129164 128448  34672 S   4.3   0.8  24:49.09 /usr/bin/crio --enable-metrics=true --metrics-port=9537
  17572 1000270+  20   0 1501444  74052  30812 S   4.3   0.5   3:27.12 cluster-samples-operator
  19962 root      20   0 9064284 722212 102668 R   4.3   4.4 249:08.18 etcd --initial-advertise-peer-urls=https://10.10.94.208:2380 --cert-file=/etc/kubernetes/static-pod-certs/secrets/etcd-+
1240805 root      20   0 1862296   1.1g  76032 S   4.3   7.0  45:44.99 kube-apiserver --openshift-config=/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml --advertise-addres+
[...]
~~~