### PR TITLE
fix/gather-monitoring: changing from thanos-querier to prom-k8s route

### DIFF
--- a/collection-scripts/gather-monitoring-data
+++ b/collection-scripts/gather-monitoring-data
@@ -199,6 +199,10 @@ function init {
     declare -g MONIT_NS="openshift-monitoring"
     declare -g MONIT_ENV="must-gather-env"
 
+    # prometheus-k8s | thanos-querier : TODO need to validate thanos-querier endpoints
+    local prom_route_name="${PROM_ROUTE_NAME:-"prometheus-k8s"}"
+    declare -g PROM_API_PATH="/api/v1"
+
     declare -g MG_BASE_PATH="${MG_BASE_PATH:-"/must-gather"}"
     declare -g MG_MONITORING_PATH="${MG_BASE_PATH}/monitoring"
     declare -g MG_PROM_PATH="${MG_MONITORING_PATH}/prometheus"
@@ -213,8 +217,7 @@ function init {
 
     # Setting: Session token, overwriten by GATHER_MONIT_TOKEN
     declare -g SS_TOKEN="${GATHER_MONIT_TOKEN:-$(oc whoami -t)}"
-    declare -g PROM_HOST=$(oc -n "${MONIT_NS}" get route thanos-querier -o jsonpath='{.spec.host}{"\n"}')
-    declare -g PROM_API_PATH="/api/v1"
+    declare -g PROM_HOST=$(oc -n "${MONIT_NS}" get route "${prom_route_name}" -o jsonpath='{.spec.host}{"\n"}')
 
     # Query Param: 'start' and 'end' timestamp
     local date_start_human=${GATHER_MONIT_START_DATE:-${GATHER_MONIT_START_DATE_DEFAULT}}


### PR DESCRIPTION
Thanos seems to be not compatible with endpoints used to query to Prometheus. Backing to use Prometheus route instead of Thanos-querier:

~~~bash
# Thanos-querier route collector
$ zcat must-gather-metrics-thanos/monitoring/prometheus/metrics/query_range-scheduler_queue_incoming_pods_total.json.gz 
{"status":"success","data":{"resultType":"matrix","result":[]},"warnings":["No StoreAPIs matched for this query"]}

# Prometheus route collector
$ zcat must-gather-metrics-prom/monitoring/prometheus/metrics/query_range-scheduler_queue_incoming_pods_total.json.gz |head
{"status":"success","data":{"resultType":"matrix","result":[{"metric":{"__name__":"scheduler_queue_incoming_pods_total","container":"kube-scheduler","endpoint":"https","event":"AssignedPodDelete","instance":"10.0.89.164:10259","job":"scheduler","namespace":"openshift-kube-scheduler","pod":"openshift-kube-scheduler-master-2.sharedocp4upi47.lab.upshift","queue":"active","service":"scheduler"},"values":[[1626418434,"1165"],[1626418494,"1172" .... 

~~~